### PR TITLE
fix #32 - gracefully end req on json parse error

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,15 +35,15 @@ var server = http.createServer(function (req, res) {
 
         try {
           args = JSON.parse(args)
+          cssFeatures(args, res)
         } catch (e) {
-          debug('Error parsing request ', args, e)
+          debug('Error parsing request ', e.toString(), args)
           res.statusCode = 400
           res.end(JSON.stringify({
             error: e.toString(),
             statusCode: 400
           }))
         }
-        cssFeatures(args, res)
       }),
       function (err) {
         if (err) { console.error(err) }


### PR DESCRIPTION
I discovered that sending a badly-formed POST request was causing #32. The code was catching the error and calling `res.end` but control still passed thru to `cssFeatures` which tried to call `setHeaders` on the `res`.

This moves the `cssFeatures` call up into the `try` block with the `JSON.parse` call.